### PR TITLE
Wait for an output readiness before downloading it. Fails if download…

### DIFF
--- a/wft4galaxy/runner.py
+++ b/wft4galaxy/runner.py
@@ -648,7 +648,10 @@ class WorkflowTestCaseRunner(_unittest.TestCase):
                 _logger.debug("Checking OUTPUT '%s' ...", output.name)
                 output_filename = _os.path.join(output_folder, output.name)
                 with open(output_filename, "wb") as out_file:
+                    output.wait()
                     output.download(out_file)
+                    if output.file_size == 0:
+                        _logger.error("Downloaded an empty file for output {0} (dataset_id '{1}', filename '{2}').".format(output_filename, output.id, output_filename))
                     output_file_map[output.name] = {"dataset": output, "filename": output_filename}
                     _logger.debug(
                         "Downloaded output {0}: dataset_id '{1}', filename '{2}'".format(output.name, output.id,


### PR DESCRIPTION
…ed file is empty.
----
I've added these lines in order to be on the safe side.
Tell me if the "file empty" test could cause issues with some workflow test. Maybe we can make it an option on the command line or better: test if an expected output is also empty.