### PR TITLE
Feature/http config

### DIFF
--- a/examples/change_case/workflow-test.yml
+++ b/examples/change_case/workflow-test.yml
@@ -38,6 +38,15 @@
 # Enable to print yet more information
 #enable_debug: True
 
+# Maximum number of retries after a connection failure
+# max_retries: 10
+
+# Delay between consecutive retries
+# retry_delay: 1
+
+# Wait time between consecutive checks of the workflow state
+# polling_interval: 1
+
 ##########################################################################################
 #  Workflow tests
 ##########################################################################################

--- a/examples/change_case/workflow-test.yml
+++ b/examples/change_case/workflow-test.yml
@@ -41,10 +41,10 @@
 # Maximum number of retries after a connection failure
 # max_retries: 10
 
-# Delay between consecutive retries
+# Delay between consecutive retries (in seconds)
 # retry_delay: 1
 
-# Wait time between consecutive checks of the workflow state
+# Wait time between consecutive checks of the workflow state (in seconds)
 # polling_interval: 1
 
 ##########################################################################################

--- a/wft4galaxy/app/runner.py
+++ b/wft4galaxy/app/runner.py
@@ -45,8 +45,8 @@ def _make_parser():
     parser.add_argument('-o', '--output', dest="output_folder", metavar="PATH", help='Path of the output folder')
 
     parser.add_argument('--max-retries', type=_check_positive, help='Max number of retries', default=None)
-    parser.add_argument('--retry-delay', type=_check_positive, help='Delay between retries', default=None)
-    parser.add_argument('--polling-interval', type=_check_positive, help='Delay between polling requests', default=None)
+    parser.add_argument('--retry-delay', type=_check_positive, help='Delay between retries in seconds', default=None)
+    parser.add_argument('--polling-interval', type=_check_positive, help='Delay between polling requests in seconds', default=None)
 
     return parser
 

--- a/wft4galaxy/app/runner.py
+++ b/wft4galaxy/app/runner.py
@@ -20,6 +20,13 @@ class _CustomFormatter(_argparse.RawTextHelpFormatter):
         super(_CustomFormatter, self).__init__(prog, indent_increment, max_help_position, width)
 
 
+def _check_positive(value):
+    int_value = int(value)
+    if int_value <= 0:
+        raise _argparse.ArgumentTypeError("%s is an invalid positive int value" % value)
+    return int_value
+
+
 def _make_parser():
     parser = _argparse.ArgumentParser(add_help=True, formatter_class=_CustomFormatter)
     parser.add_argument("test", help="Workflow Test Name", nargs="*")
@@ -33,10 +40,14 @@ def _make_parser():
     parser.add_argument('--disable-cleanup', help='Disable cleanup', action='store_true', default=None)
 
     parser.add_argument('--output-format', choices=OutputFormat, help='Choose output type', default=OutputFormat.text)
-
     parser.add_argument('--xunit-file', default=None, metavar="FILE_PATH",
                         help='Set the path of the xUnit report file (absolute or relative to the output folder)')
     parser.add_argument('-o', '--output', dest="output_folder", metavar="PATH", help='Path of the output folder')
+
+    parser.add_argument('--max-retries', type=_check_positive, help='Max number of retries', default=None)
+    parser.add_argument('--retry-delay', type=_check_positive, help='Delay between retries', default=None)
+    parser.add_argument('--polling-interval', type=_check_positive, help='Delay between polling requests', default=None)
+
     return parser
 
 
@@ -54,56 +65,11 @@ def _parse_cli_arguments(parser, cmd_args):
     return args
 
 
-def _configure_test(galaxy_url, galaxy_api_key, suite, output_folder, tests,
-                    enable_logger, enable_debug, disable_cleanup, disable_assertions):
-    # configure `galaxy_url`
-    suite.galaxy_url = galaxy_url or suite.galaxy_url or _os.environ.get(_common.ENV_KEY_GALAXY_URL)
-    if not suite.galaxy_url:
-        raise _common.TestConfigError("Galaxy URL not defined!  Use --server or the environment variable {} "
-                                      "or specify it in the test configuration".format(_common.ENV_KEY_GALAXY_URL))
-    # configure `galaxy_api_key`
-    suite.galaxy_api_key = galaxy_api_key \
-                           or suite.galaxy_api_key \
-                           or _os.environ.get(_common.ENV_KEY_GALAXY_API_KEY)
-    if not suite.galaxy_api_key:
-        raise _common.TestConfigError("Galaxy API key not defined!  Use --api-key or the environment variable {} "
-                                      "or specify it in the test configuration".format(_common.ENV_KEY_GALAXY_API_KEY))
-    # configure `output_folder`
-    suite.output_folder = output_folder \
-                          or suite.output_folder \
-                          or _core.WorkflowTestCase.DEFAULT_OUTPUT_FOLDER
-
-    if enable_logger is not None:
-        suite.enable_logger = enable_logger
-
-    if enable_debug is not None:
-        suite.enable_debug = enable_debug
-
-    if disable_cleanup is not None:
-        suite.disable_cleanup = disable_cleanup
-
-    if disable_assertions is not None:
-        suite.disable_assertions = disable_assertions
-
-    for test_config in suite.workflow_tests.values():
-        test_config.disable_cleanup = suite.disable_cleanup
-        test_config.disable_assertions = suite.disable_assertions
-
-    # enable the logger with the proper detail level
-    if suite.enable_logger or suite.enable_debug:
-        _common.LoggerManager.update_log_level(_logging.DEBUG if suite.enable_debug else _logging.INFO)
-
-    # log Python version
-    _logger.debug("Python version: %s", _sys.version)
-
-    # log the current configuration
-    _logger.info("Configuration: %s", suite)
-
-
 def run_tests(filename,
               galaxy_url=None, galaxy_api_key=None,
               enable_logger=None, enable_debug=None,
               disable_cleanup=None, disable_assertions=None,
+              max_retries=None, retry_delay=None, polling_interval=None,
               output_folder=None, enable_xunit=False, xunit_file=None, tests=None):
     """
     Run a workflow test suite defined in a configuration file.
@@ -154,6 +120,9 @@ def main():
             show_logger_name=True if options.debug else False
         )
 
+        # log Python version
+        _logger.debug("Python version: %s", _sys.version)
+
         # run tests and collect exit code
         code = run_tests(filename=options.file,
                          galaxy_url=options.galaxy_url,
@@ -162,6 +131,9 @@ def main():
                          enable_logger=options.enable_logger,
                          enable_debug=options.debug,
                          disable_cleanup=options.disable_cleanup,
+                         max_retries=options.max_retries,
+                         retry_delay=options.retry_delay,
+                         polling_interval=options.polling_interval,
                          enable_xunit=(options.output_format == OutputFormat.xunit),
                          xunit_file=options.xunit_file,
                          tests=options.test)

--- a/wft4galaxy/app/runner.py
+++ b/wft4galaxy/app/runner.py
@@ -126,15 +126,16 @@ def run_tests(filename,
     # load suite configuration
     suite = _core.WorkflowTestSuite.load(filename,
                                          output_folder=output_folder)  # FIXME: do we need output_folder here ?
-    _configure_test(galaxy_url=galaxy_url, galaxy_api_key=galaxy_api_key,
-                    suite=suite, tests=tests, output_folder=output_folder,
-                    enable_logger=enable_logger, enable_debug=enable_debug,
-                    disable_cleanup=disable_cleanup, disable_assertions=disable_assertions)
+    # log the current configuration
+    _logger.info("Configuration: %s", suite)
 
     # run the configured test suite
-    result = suite.run(galaxy_url=galaxy_url, galaxy_api_key=galaxy_api_key, verbosity=2,
+    result = suite.run(galaxy_url=galaxy_url, galaxy_api_key=galaxy_api_key, verbosity=2, tests=tests,
                        enable_xunit=enable_xunit or (xunit_file != None), xunit_file=xunit_file,
-                       enable_logger=enable_logger, enable_debug=enable_debug, disable_cleanup=disable_cleanup)
+                       output_folder=output_folder,
+                       enable_logger=enable_logger, enable_debug=enable_debug,
+                       disable_cleanup=disable_cleanup, disable_assertions=disable_assertions,
+                       max_retries=max_retries, retry_delay=retry_delay, polling_interval=polling_interval)
     # compute exit code
     exit_code = len([r for r in result.test_case_results if r.failed()])
     _logger.debug("wft4galaxy.run_tests exiting with code: %s", exit_code)

--- a/wft4galaxy/common.py
+++ b/wft4galaxy/common.py
@@ -140,55 +140,6 @@ def makedirs(path, check_if_exists=False):
             raise OSError(e.message)
 
 
-def configure_env_galaxy_server_instance(config, options, base_config=None):
-    config["galaxy_url"] = options.galaxy_url \
-                           or base_config and base_config.get("galaxy_url") \
-                           or _os.environ.get(ENV_KEY_GALAXY_URL)
-    if not config["galaxy_url"]:
-        raise TestConfigError("Galaxy URL not defined!  Use --server or the environment variable {} "
-                              "or specify it in the test configuration".format(ENV_KEY_GALAXY_URL))
-
-    config["galaxy_api_key"] = options.galaxy_api_key \
-                               or base_config and base_config.get("galaxy_api_key") \
-                               or _os.environ.get(ENV_KEY_GALAXY_API_KEY)
-    if not config["galaxy_api_key"]:
-        raise TestConfigError("Galaxy API key not defined!  Use --api-key or the environment variable {} "
-                              "or specify it in the test configuration".format(ENV_KEY_GALAXY_API_KEY))
-
-
-def get_galaxy_instance(galaxy_url=None, galaxy_api_key=None):
-    """
-    Private utility function to instantiate and configure a :class:`bioblend.GalaxyInstance`
-
-    :type galaxy_url: str
-    :param galaxy_url: the URL of the Galaxy server
-
-    :type galaxy_api_key: str
-    :param galaxy_api_key: a registered Galaxy API KEY
-
-    :rtype: :class:`bioblend.objects.GalaxyInstance`
-    :return: a new :class:`bioblend.objects.GalaxyInstance` instance
-    """
-    # configure `galaxy_url`
-    if galaxy_url is None:
-        if ENV_KEY_GALAXY_URL not in _os.environ:
-            raise TestConfigError("Galaxy URL not defined!  Use --server or the environment variable {} "
-                                  "or specify it in the test configuration".format(ENV_KEY_GALAXY_URL))
-        else:
-            galaxy_url = _os.environ[ENV_KEY_GALAXY_URL]
-
-    # configure `galaxy_api_key`
-    if galaxy_api_key is None:
-        if ENV_KEY_GALAXY_API_KEY not in _os.environ:
-            raise TestConfigError("Galaxy API key not defined!  Use --api-key or the environment variable {} "
-                                  "or specify it in the test configuration".format(ENV_KEY_GALAXY_API_KEY))
-        else:
-            galaxy_api_key = _os.environ[ENV_KEY_GALAXY_API_KEY]
-
-    # initialize the galaxy instance
-    return ObjGalaxyInstance(galaxy_url, galaxy_api_key)
-
-
 class WorkflowLoader(object):
     """
     Singleton utility class responsible for loading (unloading) workflows to (from) a Galaxy server.
@@ -357,3 +308,53 @@ class GalaxyInstance(ObjGalaxyInstance):
     def polling_interval(self, interval):
         self._polling_interval = interval
 
+
+def configure_env_galaxy_server_instance(config, options, base_config=None):
+    config["galaxy_url"] = options.galaxy_url \
+                           or base_config and base_config.get("galaxy_url") \
+                           or _os.environ.get(ENV_KEY_GALAXY_URL)
+    if not config["galaxy_url"]:
+        raise TestConfigError("Galaxy URL not defined!  Use --server or the environment variable {} "
+                              "or specify it in the test configuration".format(ENV_KEY_GALAXY_URL))
+
+    config["galaxy_api_key"] = options.galaxy_api_key \
+                               or base_config and base_config.get("galaxy_api_key") \
+                               or _os.environ.get(ENV_KEY_GALAXY_API_KEY)
+    if not config["galaxy_api_key"]:
+        raise TestConfigError("Galaxy API key not defined!  Use --api-key or the environment variable {} "
+                              "or specify it in the test configuration".format(ENV_KEY_GALAXY_API_KEY))
+
+
+def get_galaxy_instance(galaxy_url=None, galaxy_api_key=None,
+                        max_retries=MAX_RETRIES, retry_delay=RETRY_DELAY, polling_interval=POLLING_INTERVAL):
+    """
+    Private utility function to instantiate and configure a :class:`bioblend.GalaxyInstance`
+
+    :type galaxy_url: str
+    :param galaxy_url: the URL of the Galaxy server
+
+    :type galaxy_api_key: str
+    :param galaxy_api_key: a registered Galaxy API KEY
+
+    :rtype: :class:`bioblend.objects.GalaxyInstance`
+    :return: a new :class:`bioblend.objects.GalaxyInstance` instance
+    """
+    # configure `galaxy_url`
+    if galaxy_url is None:
+        if ENV_KEY_GALAXY_URL not in _os.environ:
+            raise TestConfigError("Galaxy URL not defined!  Use --server or the environment variable {} "
+                                  "or specify it in the test configuration".format(ENV_KEY_GALAXY_URL))
+        else:
+            galaxy_url = _os.environ[ENV_KEY_GALAXY_URL]
+
+    # configure `galaxy_api_key`
+    if galaxy_api_key is None:
+        if ENV_KEY_GALAXY_API_KEY not in _os.environ:
+            raise TestConfigError("Galaxy API key not defined!  Use --api-key or the environment variable {} "
+                                  "or specify it in the test configuration".format(ENV_KEY_GALAXY_API_KEY))
+        else:
+            galaxy_api_key = _os.environ[ENV_KEY_GALAXY_API_KEY]
+
+    # initialize the galaxy instance
+    return GalaxyInstance(galaxy_url, galaxy_api_key,
+                          max_retries=max_retries, retry_delay=retry_delay, polling_interval=polling_interval)

--- a/wft4galaxy/common.py
+++ b/wft4galaxy/common.py
@@ -8,16 +8,17 @@ import types as _types
 import logging as _logging
 import datetime as _datetime
 
-# bioblend dependencies
+# BioBlend dependency
 from bioblend.galaxy.objects import GalaxyInstance as ObjGalaxyInstance
 
 # Galaxy ENV variable names
 ENV_KEY_GALAXY_URL = "GALAXY_URL"
 ENV_KEY_GALAXY_API_KEY = "GALAXY_API_KEY"
 
-# configure logger
-
-
+# http settings
+MAX_RETRIES = 1
+RETRY_DELAY = 10
+POLLING_INTERVAL = 10
 
 # map `StandardError` to `Exception` to allow compatibility both with Python2 and Python3
 RunnerStandardError = Exception
@@ -318,3 +319,41 @@ class WorkflowLoader(object):
             raise RuntimeError("WorkflowLoader not initialized")
         for _, wf in _iteritems(self._workflows):
             self.unload_workflow(wf.id)
+
+
+# GalaxyInstance wrapper
+class GalaxyInstance(ObjGalaxyInstance):
+    def __init__(self, url, api_key=None, email=None, password=None,
+                 max_retries=MAX_RETRIES, retry_delay=RETRY_DELAY, polling_interval=POLLING_INTERVAL):
+        super(GalaxyInstance, self).__init__(url, api_key, email, password)
+        if max_retries is not None:
+            self.max_retries = max_retries
+        if retry_delay is not None:
+            self.retry_delay = retry_delay
+        if polling_interval is not None:
+            self.polling_interval = polling_interval
+
+    @property
+    def max_retries(self):
+        return self.gi.max_get_attempts
+
+    @max_retries.setter
+    def max_retries(self, v):
+        self.gi.max_get_attempts = v
+
+    @property
+    def retry_delay(self):
+        return self.gi.get_retry_delay
+
+    @retry_delay.setter
+    def retry_delay(self, v):
+        self.gi.get_retry_delay = v
+
+    @property
+    def polling_interval(self):
+        return self._polling_interval
+
+    @polling_interval.setter
+    def polling_interval(self, interval):
+        self._polling_interval = interval
+

--- a/wft4galaxy/runner.py
+++ b/wft4galaxy/runner.py
@@ -92,10 +92,10 @@ class WorkflowTestsRunner():
             test.disable_assertions = disable_assertions
 
         # update http properties
-        self._galaxy_instance.max_retries = max_retries or getattr(test, "max_retries") or _common.MAX_RETRIES
-        self._galaxy_instance.retry_delay = retry_delay or getattr(test, "retry_delay") or _common.RETRY_DELAY
+        self._galaxy_instance.max_retries = max_retries or getattr(test, "max_retries", None) or _common.MAX_RETRIES
+        self._galaxy_instance.retry_delay = retry_delay or getattr(test, "retry_delay", None) or _common.RETRY_DELAY
         self._galaxy_instance.polling_interval = polling_interval \
-                                                 or getattr(test, "polling_interval") or _common.POLLING_INTERVAL
+                                                 or getattr(test, "polling_interval", None) or _common.POLLING_INTERVAL
 
         # update verbosity level
         self._runner.verbosity = verbosity

--- a/wft4galaxy/runner.py
+++ b/wft4galaxy/runner.py
@@ -24,9 +24,6 @@ import wft4galaxy.core as _core
 from wft4galaxy import common as _common
 from wft4galaxy import comparators as _comparators
 
-# http settings
-from common import MAX_RETRIES, RETRY_DELAY, POLLING_INTERVAL
-
 # the encoding name needs to be one of
 # http://www.iana.org/assignments/character-sets/character-sets.xhtml
 _UTF8 = 'UTF-8'
@@ -95,9 +92,10 @@ class WorkflowTestsRunner():
             test.disable_assertions = disable_assertions
 
         # update http properties
-        self._galaxy_instance.max_retries = max_retries or getattr(test, "max_retries", MAX_RETRIES)
-        self._galaxy_instance.retry_delay = retry_delay or getattr(test, "retry_delay", RETRY_DELAY)
-        self._galaxy_instance.polling_interval = polling_interval or getattr(test, "polling_interval", POLLING_INTERVAL)
+        self._galaxy_instance.max_retries = max_retries or getattr(test, "max_retries") or _common.MAX_RETRIES
+        self._galaxy_instance.retry_delay = retry_delay or getattr(test, "retry_delay") or _common.RETRY_DELAY
+        self._galaxy_instance.polling_interval = polling_interval \
+                                                 or getattr(test, "polling_interval") or _common.POLLING_INTERVAL
 
         # update verbosity level
         self._runner.verbosity = verbosity

--- a/wft4galaxy/runner.py
+++ b/wft4galaxy/runner.py
@@ -9,6 +9,7 @@ import shutil as _shutil
 import logging as _logging
 import unittest as _unittest
 from uuid import uuid1 as _uuid1
+
 try:
     from StringIO import StringIO as _StringIO
 except ImportError:
@@ -22,6 +23,9 @@ from xmlrunner.result import _XMLTestResult
 import wft4galaxy.core as _core
 from wft4galaxy import common as _common
 from wft4galaxy import comparators as _comparators
+
+# http settings
+from common import MAX_RETRIES, RETRY_DELAY, POLLING_INTERVAL
 
 # the encoding name needs to be one of
 # http://www.iana.org/assignments/character-sets/character-sets.xhtml
@@ -55,12 +59,15 @@ class WorkflowTestsRunner():
     """
 
     def __init__(self, galaxy_url=None, galaxy_api_key=None,
+                 max_retries=None, retry_delay=None, polling_interval=None,
                  output_folder='.', stream=_sys.stderr,
                  descriptions=True, verbosity=1, elapsed_times=True):
         self.galaxy_api_key = galaxy_api_key
 
         # create Galaxy instance
-        self._galaxy_instance = _common.get_galaxy_instance(galaxy_url, galaxy_api_key)
+        self._galaxy_instance = _common.get_galaxy_instance(galaxy_url, galaxy_api_key,
+                                                            max_retries=max_retries, retry_delay=retry_delay,
+                                                            polling_interval=polling_interval)
 
         # create WorkflowLoader
         self._workflow_loader = _common.WorkflowLoader.get_instance(self._galaxy_instance)
@@ -74,7 +81,8 @@ class WorkflowTestsRunner():
                                               descriptions=descriptions, elapsed_times=elapsed_times)
 
     def _setup(self, test, output_folder=None, verbosity=2,
-               disable_assertions=None, disable_cleanup=None, enable_logger=None, enable_debug=None):
+               disable_assertions=None, disable_cleanup=None, enable_logger=None, enable_debug=None,
+               max_retries=None, retry_delay=None, polling_interval=None):
         """ Update runner configuration accordingly to the test configuration"""
 
         if enable_logger is not None:
@@ -85,6 +93,11 @@ class WorkflowTestsRunner():
             test.disable_cleanup = disable_cleanup
         if disable_assertions is not None:
             test.disable_assertions = disable_assertions
+
+        # update http properties
+        self._galaxy_instance.max_retries = max_retries or getattr(test, "max_retries", MAX_RETRIES)
+        self._galaxy_instance.retry_delay = retry_delay or getattr(test, "retry_delay", RETRY_DELAY)
+        self._galaxy_instance.polling_interval = polling_interval or getattr(test, "polling_interval", POLLING_INTERVAL)
 
         # update verbosity level
         self._runner.verbosity = verbosity
@@ -113,7 +126,8 @@ class WorkflowTestsRunner():
     def run(self, test, filter=None, stream=_sys.stderr, verbosity=2,
             output_folder=None, output_suffix=None,
             report_format=None, report_filename=None,
-            disable_assertions=None, disable_cleanup=None, enable_logger=None, enable_debug=None):
+            disable_assertions=None, disable_cleanup=None, enable_logger=None, enable_debug=None,
+            max_retries=None, retry_delay=None, polling_interval=None):
 
         """ Run a single test case or a suite of test cases. """
 
@@ -123,7 +137,8 @@ class WorkflowTestsRunner():
         # update configuration
         self._setup(test, output_folder=output_folder, verbosity=verbosity,
                     disable_assertions=disable_assertions, disable_cleanup=disable_cleanup,
-                    enable_logger=enable_logger, enable_debug=enable_debug)
+                    enable_logger=enable_logger, enable_debug=enable_debug,
+                    max_retries=max_retries, retry_delay=retry_delay, polling_interval=polling_interval)
 
         # prepare wrappers
         self._logger.debug("Creating unittest wrappers...")
@@ -542,7 +557,8 @@ class WorkflowTestCaseRunner(_unittest.TestCase):
 
                 # run the workflow
                 _logger.info("Workflow '%s' (id: %s) running ...", workflow.name, workflow.id)
-                outputs, output_history = workflow.run(datamap, history, params=params, wait=True, polling_interval=0.5)
+                outputs, output_history = workflow.run(datamap, history, params=params, wait=True,
+                                                       polling_interval=self._galaxy_instance.polling_interval)
                 _logger.info("Workflow '%s' (id: %s) executed", workflow.name, workflow.id)
 
                 # check outputs


### PR DESCRIPTION
This PR introduces the possibility to configure (via CLI or configuration file) the main three parameters which regulate the HTTP communication between the BioBlend API and a Galaxy server instance, i.e.,:

* _max_retries_ e _delay_retry_ after a connection failure;
* _polling_interval_ between consecutive checks of the workflow state.